### PR TITLE
Updated authentication_url to be able to pass in scopes

### DIFF
--- a/nylas/client/client.py
+++ b/nylas/client/client.py
@@ -142,13 +142,23 @@ class APIClient(json.JSONEncoder):
             if 'Authorization' in self.session.headers:
                 del self.session.headers['Authorization']
 
-    def authentication_url(self, redirect_uri, login_hint='', state=''):
+    def authentication_url(
+        self,
+        redirect_uri,
+        login_hint='',
+        state='',
+        scopes=("email", "calendar", "contacts"),
+    ):
         args = {'redirect_uri': redirect_uri,
                 'client_id': self.app_id or 'None',  # 'None' for back-compat
                 'response_type': 'code',
-                'scope': 'email',
                 'login_hint': login_hint,
                 'state': state}
+
+        if scopes:
+            if isinstance(scopes, str):
+                scopes = [scopes]
+            args["scopes"] = ",".join(scopes)
 
         url = URLObject(self.authorize_url).add_query_params(args.items())
         return str(url)


### PR DESCRIPTION
This is like the existing functionality in the master repo, but since we
are a bit behind, this is the quickest way to get this functionality
into our fork.